### PR TITLE
Methods return error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.idea

--- a/handlers.go
+++ b/handlers.go
@@ -1,99 +1,27 @@
 package aeio
 
-type Handler func(*Resource)
+type Handler func(*Resource) error
 
-func HandleCreate(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.Create(true)
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandleCreate(r *Resource) error {
+	return r.Create()
 }
 
-func HandleRead(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.Read()
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandleRead(r *Resource) error {
+	return r.Read()
 }
 
-func HandlePatch(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.Patch()
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandlePatch(r *Resource) error {
+	return r.Patch()
 }
 
-func HandleReadAll(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.ReadAll()
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandleReadAll(r *Resource) error {
+	return r.ReadAll()
 }
 
-func HandleReadAny(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.ReadAny()
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandleReadAny(r *Resource) error {
+	return r.ReadAny()
 }
 
-func HandleDelete(r *Resource) {
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	r.Delete()
-	if len(r.Errors) > 0 {
-		Forbid(r)
-		return
-	}
-
-	Allow(r)
-	return
+func HandleDelete(r *Resource) error {
+	return r.Delete()
 }

--- a/init.go
+++ b/init.go
@@ -6,8 +6,8 @@ import (
 	"log"
 )
 
-var ListSizeDefault int = 20
-var ListSizeMax int = 100
+var ListSizeDefault = 20
+var ListSizeMax = 100
 var InstanceContext context.Context
 var ShutdownContext context.CancelFunc
 var DatastoreClient *datastore.Client

--- a/registry.go
+++ b/registry.go
@@ -8,10 +8,10 @@ import (
 	"reflect"
 )
 
-//models allow aeio to instantiate new objects based on keys and paths.
-var models = make(map[string]Objector)
+// models allow aeio to instantiate new objects based on keys and paths.
+var models = make(map[string]Data)
 
-func RegisterModel(alias string, model Objector) {
+func RegisterModel(alias string, model Data) {
 	if _, ok := models[alias]; ok {
 		panic("aeio: Register called twice for model " + alias)
 	}
@@ -19,7 +19,7 @@ func RegisterModel(alias string, model Objector) {
 	models[alias] = model
 }
 
-func NewObject(alias string) (Objector, error) {
+func NewObject(alias string) (Data, error) {
 	if models[alias] == nil {
 		return nil, errors.New("Resource " + alias + " is not implemented.")
 	}
@@ -27,7 +27,7 @@ func NewObject(alias string) (Objector, error) {
 	if val.Kind() == reflect.Ptr {
 		val = reflect.Indirect(val)
 	}
-	newObj := reflect.New(val.Type()).Interface().(Objector)
+	newObj := reflect.New(val.Type()).Interface().(Data)
 
 	return newObj, nil
 }
@@ -58,7 +58,8 @@ func ValidatePaternity(p string, c string) (err error) {
 	return
 }
 
-func ValidatePaternityChain(k *datastore.Key) (err error) {
+// ValidateKey checks if the key chain is valid
+func ValidateKey(k *datastore.Key) (err error) {
 	for {
 		kind := k.Kind
 		if k.Parent != nil {
@@ -69,7 +70,7 @@ func ValidatePaternityChain(k *datastore.Key) (err error) {
 			}
 			continue
 		}
-		//no more parent, test for ""
+		// no more parent, test for ""
 		err = ValidatePaternity("", k.Kind)
 		if err != nil {
 			return


### PR DESCRIPTION
It's a clearer way to control state and idiomatic go. Maybe the property Resource.Error shoud be unexported and set finally only through the Respond function.